### PR TITLE
Adding new VoyageAI and Cohere models:

### DIFF
--- a/ebr/models/cohere.py
+++ b/ebr/models/cohere.py
@@ -39,7 +39,7 @@ class CohereEmbeddingModel(APIEmbeddingModel):
         if self.embd_dtype == "float32":
             return "float"
         else:
-            raise NotImplementedError
+            return self.embd_dtype
 
     def embed(self, data: str, input_type: str) -> list[list[float]]:
         
@@ -77,3 +77,24 @@ embed_v4_0 = ModelMeta(
     vendor="Cohere",
 )
 
+embed_v4_0_int8 = ModelMeta(
+    loader=CohereEmbeddingModel,
+    model_name="embed-v4.0",
+    embd_dtype="int8",
+    embd_dim=1536,
+    max_tokens=128_000,
+    similarity="cosine",
+    reference="https://docs.cohere.com/v2/docs/cohere-embed",
+    vendor="Cohere",
+)
+
+embed_v4_0_binary = ModelMeta(
+    loader=CohereEmbeddingModel,
+    model_name="embed-v4.0",
+    embd_dtype="binary",
+    embd_dim=1536,
+    max_tokens=128_000,
+    similarity="cosine",
+    reference="https://docs.cohere.com/v2/docs/cohere-embed",
+    vendor="Cohere",
+)

--- a/ebr/models/cohere.py
+++ b/ebr/models/cohere.py
@@ -77,22 +77,22 @@ embed_v4_0 = ModelMeta(
     vendor="Cohere",
 )
 
-embed_v4_0_int8 = ModelMeta(
+embed_v4_0_int8_512 = ModelMeta(
     loader=CohereEmbeddingModel,
     model_name="embed-v4.0",
     embd_dtype="int8",
-    embd_dim=1536,
+    embd_dim=512,
     max_tokens=128_000,
     similarity="cosine",
     reference="https://docs.cohere.com/v2/docs/cohere-embed",
     vendor="Cohere",
 )
 
-embed_v4_0_binary = ModelMeta(
+embed_v4_0_binary_256 = ModelMeta(
     loader=CohereEmbeddingModel,
     model_name="embed-v4.0",
     embd_dtype="binary",
-    embd_dim=1536,
+    embd_dim=256,
     max_tokens=128_000,
     similarity="cosine",
     reference="https://docs.cohere.com/v2/docs/cohere-embed",

--- a/ebr/models/voyageai.py
+++ b/ebr/models/voyageai.py
@@ -83,22 +83,10 @@ voyage_35 = ModelMeta(
     reference="https://docs.voyageai.com/docs/embeddings"
 )
 
-voyage_35_int8 = ModelMeta(
+voyage_35_int8_512 = ModelMeta(
     loader=VoyageAIEmbeddingModel,
     model_name="voyage-3.5",
     embd_dtype="int8",
-    embd_dim=1024,
-    max_tokens=32_000,
-    similarity="cosine",
-    query_instruct="Represent the query for retrieving supporting documents: ",
-    corpus_instruct="Represent the document for retrieval: ",
-    reference="https://docs.voyageai.com/docs/embeddings"
-)
-
-voyage_35_binary_512 = ModelMeta(
-    loader=VoyageAIEmbeddingModel,
-    model_name="voyage-3.5",
-    embd_dtype="binary",
     embd_dim=512,
     max_tokens=32_000,
     similarity="cosine",
@@ -107,10 +95,10 @@ voyage_35_binary_512 = ModelMeta(
     reference="https://docs.voyageai.com/docs/embeddings"
 )
 
-voyage_35_256 = ModelMeta(
+voyage_35_binary_256 = ModelMeta(
     loader=VoyageAIEmbeddingModel,
     model_name="voyage-3.5",
-    embd_dtype="float32",
+    embd_dtype="binary",
     embd_dim=256,
     max_tokens=32_000,
     similarity="cosine",

--- a/ebr/models/voyageai.py
+++ b/ebr/models/voyageai.py
@@ -36,11 +36,17 @@ class VoyageAIEmbeddingModel(APIEmbeddingModel):
         return self._client
 
     def embed(self, data: Any, input_type: str) -> list[list[float]]:
+        request = {
+            "texts": data,
+            "model": self.model_name,
+            "input_type": None
+        }
+        if self.model_name in ["voyage-3-large", "voyage-3.5", "voyage-3.5-lite", "voyage-code-3"]:
+            request["output_dimension"] = self.embd_dim
+            request["output_dtype"] = self.embd_dtype
+
         result = self.client.embed(
-            data,
-            model=self.model_name,
-            output_dimension=self.embd_dim,
-            input_type=None
+            **request
         )
         return result.embeddings
 
@@ -62,8 +68,7 @@ voyage_3 = ModelMeta(
     similarity="cosine",
     query_instruct="Represent the query for retrieving supporting documents: ",
     corpus_instruct="Represent the document for retrieval: ",
-    reference="https://docs.voyageai.com/docs/embeddings",
-    vendor="Voyage AI",
+    reference="https://docs.voyageai.com/docs/embeddings"
 )
 
 voyage_35 = ModelMeta(
@@ -75,6 +80,41 @@ voyage_35 = ModelMeta(
     similarity="cosine",
     query_instruct="Represent the query for retrieving supporting documents: ",
     corpus_instruct="Represent the document for retrieval: ",
-    reference="https://docs.voyageai.com/docs/embeddings",
-    vendor="Voyage AI",
+    reference="https://docs.voyageai.com/docs/embeddings"
+)
+
+voyage_35_int8 = ModelMeta(
+    loader=VoyageAIEmbeddingModel,
+    model_name="voyage-3.5",
+    embd_dtype="int8",
+    embd_dim=1024,
+    max_tokens=32_000,
+    similarity="cosine",
+    query_instruct="Represent the query for retrieving supporting documents: ",
+    corpus_instruct="Represent the document for retrieval: ",
+    reference="https://docs.voyageai.com/docs/embeddings"
+)
+
+voyage_35_binary_512 = ModelMeta(
+    loader=VoyageAIEmbeddingModel,
+    model_name="voyage-3.5",
+    embd_dtype="binary",
+    embd_dim=512,
+    max_tokens=32_000,
+    similarity="cosine",
+    query_instruct="Represent the query for retrieving supporting documents: ",
+    corpus_instruct="Represent the document for retrieval: ",
+    reference="https://docs.voyageai.com/docs/embeddings"
+)
+
+voyage_35_256 = ModelMeta(
+    loader=VoyageAIEmbeddingModel,
+    model_name="voyage-3.5",
+    embd_dtype="float32",
+    embd_dim=256,
+    max_tokens=32_000,
+    similarity="cosine",
+    query_instruct="Represent the query for retrieving supporting documents: ",
+    corpus_instruct="Represent the document for retrieval: ",
+    reference="https://docs.voyageai.com/docs/embeddings"
 )


### PR DESCRIPTION
P1: Add int8, 512 and binary, 256 for voyage-3.5 to the standalone RTEB leaderboard
P1: Add int8 and binary for Cohere Embed v4 to the standalone RTEB leaderboard